### PR TITLE
Fixing the problem of receiving the native coin of the network in the smart contract

### DIFF
--- a/contracts/Arb.sol
+++ b/contracts/Arb.sol
@@ -85,5 +85,7 @@ contract Arb is Ownable {
 		IERC20 token = IERC20(tokenAddress);
 		token.transfer(msg.sender, token.balanceOf(address(this)));
 	}
+	
+	receive() external payable {}
 
 }


### PR DESCRIPTION
The smart contract related to arbitrage is called "Arb.sol" receiving erc20 tokens, but transferring network coins to this contract such as ETH, MATIC, etc did not accept

Because the mentioned smart contract needs the receive or fallback function to receive these coins